### PR TITLE
Make the Gemfile always point to the last version of the Twitter List gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby.git', branch: 'morph_defaults'
-gem 'twitter_list', git: 'https://github.com/everypolitician/twitter_list.git'
+gem 'twitter_list', '>= 0.0.2', git: 'https://github.com/everypolitician/twitter_list.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/everypolitician/twitter_list.git
-  revision: 25087ee3d4b97a0bfeac37d9c915d018d1ce453b
+  revision: 06ec0b4521a964674ba482dfa3efc0dc43c1a1e0
   specs:
-    twitter_list (0.0.1)
+    twitter_list (0.0.2)
       twitter
 
 GIT
@@ -64,7 +64,7 @@ PLATFORMS
 
 DEPENDENCIES
   scraperwiki!
-  twitter_list!
+  twitter_list (>= 0.0.2)!
 
 BUNDLED WITH
    1.12.5


### PR DESCRIPTION
Even though the Twitter List gem was updated yesterday, the scrapers were still failing on morph.io, due to the `Gemfile.lock` still pointing at the first version of the gem (0.0.1).

Hopefully by adding `'>= 0.0.2'` in the `Gemfile`, this problem will be solved and the `Gemfile.lock` file will point to the latest version forever.
